### PR TITLE
Update version number to indicate unofficial update

### DIFF
--- a/CarryChest/manifest.json
+++ b/CarryChest/manifest.json
@@ -10,7 +10,7 @@
   "UniqueID": "spacechase0.CarryChest",
   "Name": "CarryChest",
   "Author": "spacechase0",
-  "Version": "1.3.6",
+  "Version": "1.3.6-unofficial.1-sampaiots",
   "Description": "...",
   "EntryDll": "CarryChest.dll"
 }


### PR DESCRIPTION
# Description

Naming convention: `{originalVersion}-unofficial.{unofficialIteration}-{unofficialAuthor}`

This seems to be the common naming convention I've found from other unofficially updated Stardew Valley mods.

# References

- [Wind Effects](https://forums.stardewvalley.net/threads/unofficial-mod-updates.2096/page-122#post-119900)
- [SAAT - Audio API and Toolkit](https://forums.stardewvalley.net/threads/unofficial-mod-updates.2096/page-136#post-121255)

# Note

Further improvement would be to have the unofficial mod update to be picked up by SMAPI in this [list](https://smapi.io/mods) so users can be informed of it when they launch the game, but I'm not sure how other unofficial mod updates make that happen.